### PR TITLE
Fetch external API ui-avatars to display default profile picture

### DIFF
--- a/client/src/api/admins/index.ts
+++ b/client/src/api/admins/index.ts
@@ -1,0 +1,15 @@
+import { IAdmin } from '../../types/Admin';
+
+const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}`;
+
+export const getCurrentAdminRequest = async (): Promise<IAdmin> => {
+  const res = await fetch(`${API_BASE_URL}/profile`, {
+    credentials: 'include',
+  });
+
+  if (!res.ok) throw new Error('Error Fetching current admin profile!');
+
+  const { data } = await res.json();
+
+  return data;
+};

--- a/client/src/components/Avatar.tsx
+++ b/client/src/components/Avatar.tsx
@@ -1,5 +1,8 @@
 import { useGetCurrentAdmin } from '../hooks/admins';
 import styled from 'styled-components';
+import Spinner from './Spinner';
+import SpinnerContainer from './ui/SpinnerContainer';
+
 const StyledAvatar = styled.div`
   display: flex;
   align-items: center;
@@ -21,22 +24,27 @@ const AvatarImg = styled.img`
 `;
 
 const Avatar = () => {
-  const { admin } = useGetCurrentAdmin();
-  const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}/profile`;
+  const { admin, isAdminLoading } = useGetCurrentAdmin();
 
+  const fallbackAvatarImg = `https://ui-avatars.com/api/?name=${encodeURIComponent(admin?.name ?? '')}&background=random`;
 
-  if (!admin) return null;
-
-  const fallbackAvatarImg = `https://ui-avatars.com/api/?name=${encodeURIComponent(admin.name)}&background=random`;
-
-  const imageUrl = admin.image 
-    ? `${API_BASE_URL}/${admin.image}` 
+  const imageUrl = admin?.image
+    ? admin.image
     : fallbackAvatarImg;
 
   return (
     <StyledAvatar>
-      <AvatarImg src={imageUrl} alt={`Avatar for ${admin.name}`} />
-      <span>{admin.name}</span>
+      {isAdminLoading ? (
+          <SpinnerContainer>
+           <Spinner size="sm" />
+          </SpinnerContainer>
+
+      ):  (
+        <>
+          <AvatarImg src={imageUrl} alt={`Avatar for ${admin?.name}`} />
+          <span>{admin?.name}</span>
+        </>
+      )}
     </StyledAvatar>
   );
 };

--- a/client/src/components/Avatar.tsx
+++ b/client/src/components/Avatar.tsx
@@ -1,5 +1,10 @@
 import styled from 'styled-components';
 
+interface Props {
+  UserName: string;
+  profileImageUrl: string;
+}
+
 const StyledAvatar = styled.div`
   display: flex;
   align-items: center;
@@ -20,11 +25,19 @@ const AvatarImg = styled.img`
   outline: 2px solid var(--color-gray-100);
 `;
 
-const Avatar = () => {
+const Avatar = ({ UserName, profileImageUrl }: Props) => {
+  const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}/profile`;
+
+  const fallbackAvatarImg = `https://ui-avatars.com/api/?name=${encodeURIComponent(UserName)}&background=random`;
+
+  const imageUrl = profileImageUrl 
+    ? `${API_BASE_URL}/${profileImageUrl}` 
+    : fallbackAvatarImg;
+
   return (
     <StyledAvatar>
-      <AvatarImg />
-      <span>UserName</span>
+      <AvatarImg src={imageUrl} alt={`Avatar for ${UserName}`} />
+      <span>{UserName}</span>
     </StyledAvatar>
   );
 };

--- a/client/src/components/Avatar.tsx
+++ b/client/src/components/Avatar.tsx
@@ -1,10 +1,5 @@
+import { useGetCurrentAdmin } from '../hooks/admins';
 import styled from 'styled-components';
-
-interface Props {
-  UserName: string;
-  profileImageUrl: string;
-}
-
 const StyledAvatar = styled.div`
   display: flex;
   align-items: center;
@@ -25,19 +20,23 @@ const AvatarImg = styled.img`
   outline: 2px solid var(--color-gray-100);
 `;
 
-const Avatar = ({ UserName, profileImageUrl }: Props) => {
+const Avatar = () => {
+  const { admin } = useGetCurrentAdmin();
   const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}/profile`;
 
-  const fallbackAvatarImg = `https://ui-avatars.com/api/?name=${encodeURIComponent(UserName)}&background=random`;
 
-  const imageUrl = profileImageUrl 
-    ? `${API_BASE_URL}/${profileImageUrl}` 
+  if (!admin) return null;
+
+  const fallbackAvatarImg = `https://ui-avatars.com/api/?name=${encodeURIComponent(admin.name)}&background=random`;
+
+  const imageUrl = admin.image 
+    ? `${API_BASE_URL}/${admin.image}` 
     : fallbackAvatarImg;
 
   return (
     <StyledAvatar>
-      <AvatarImg src={imageUrl} alt={`Avatar for ${UserName}`} />
-      <span>{UserName}</span>
+      <AvatarImg src={imageUrl} alt={`Avatar for ${admin.name}`} />
+      <span>{admin.name}</span>
     </StyledAvatar>
   );
 };

--- a/client/src/hooks/admins/index.ts
+++ b/client/src/hooks/admins/index.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCurrentAdminRequest } from '../../api/admins';
+import toast from 'react-hot-toast';
+import { IAdmin } from '../../types/Admin';
+
+
+export const useGetCurrentAdmin = () => {
+    const {
+      data: admin,
+      isLoading: isAdminLoading,
+      error,
+    } = useQuery<IAdmin, Error>({
+      queryKey: ['getCurrentAdmin'],
+      queryFn: getCurrentAdminRequest
+    });
+  
+    if (error) toast.error(error.message);
+  
+    return {
+      admin,
+      isAdminLoading,
+    };
+  };


### PR DESCRIPTION
## Display Profile picture:

- Create a new request to fetch the current admin profile data.
- Create a new hook to use the request and return the desired data.
- Update the Avatar component to display the profile picture or the default avatar based on the admin name.
 
Before:

![before_avater](https://github.com/user-attachments/assets/0e3f0233-55f6-41c1-b512-e8d2d0313259)


After:

![after_avatar](https://github.com/user-attachments/assets/0caea7b1-a671-42c1-a448-1a31d1a9dfcb)
